### PR TITLE
Reduce shutdown click threshold

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,7 +432,7 @@ void loop() {
     }
     lastClickTime = millis();
 
-    if (clickCount >= 5) {
+    if (clickCount >= 3) {
       hotend.setTargetTemp(0);
       motor.setSpeed(0, 8);
       motor.disable();


### PR DESCRIPTION
## Summary
- Trigger emergency shutdown after three clicks instead of five

## Testing
- `pio run` *(fails: command not found)*
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66c9388c832ab39eb9a2324ac838