### PR TITLE
Add thermistor computeTemp tests

### DIFF
--- a/include/thermistor.h
+++ b/include/thermistor.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <stdint.h>
+
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+#ifndef pgm_read_word
+#define pgm_read_word(addr) (*(const short *)(addr))
+#endif
+
+float computeTemp(int rawADC);
+
+extern const short temptable_100K[][2];

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,5 +9,9 @@ lib_deps =
     olikraus/U8g2@^2.33.2
     https://github.com/GyverLibs/GyverStepper.git
     https://github.com/gyverlibs/GyverEncoder.git
-	https://github.com/gyverlibs/GyverPID.git
-	teemuatlut/TMCStepper@^0.7.3
+        https://github.com/gyverlibs/GyverPID.git
+        teemuatlut/TMCStepper@^0.7.3
+
+[env:native]
+platform = native
+build_src_filter = +<thermistor.cpp>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <HardwareTimer.h>
 #include <GyverPID.h>
 #include <EEPROM.h>
+#include "thermistor.h"
 
 struct PIDParams {
   uint32_t magic = 0xDEADBEEF;  // уникальный "флаг"
@@ -43,16 +44,6 @@ bool tuningInProgress = false;
 #define MAX_SPEED 1000.0f
 #define SPEED_STEP 5.0f
 
-const short temptable_100K[][2] PROGMEM = {
-  {    1, 864 }, {   21, 300 }, {   25, 290 }, {   29, 280 },
-  {   33, 270 }, {   39, 260 }, {   46, 250 }, {   54, 240 },
-  {   64, 230 }, {   75, 220 }, {   90, 210 }, {  107, 200 },
-  {  128, 190 }, {  154, 180 }, {  184, 170 }, {  221, 160 },
-  {  265, 150 }, {  316, 140 }, {  375, 130 }, {  441, 120 },
-  {  513, 110 }, {  588, 100 }, {  734,  80 }, {  856,  60 },
-  {  938,  40 }, {  986,  20 }, { 1008,   0 }, { 1018, -20 }
-};
-
 HardwareTimer *timer = new HardwareTimer(TIM1);
 
 bool fullStopTriggered = false;
@@ -73,18 +64,6 @@ class Thermistor {
     }
     int raw() { return _lastRaw; }
   private:
-    float computeTemp(int rawADC) {
-      for (uint8_t i = 1; i < sizeof(temptable_100K)/sizeof(*temptable_100K); i++) {
-        if (pgm_read_word(&temptable_100K[i][0]) > rawADC) {
-          float adc1 = pgm_read_word(&temptable_100K[i-1][0]);
-          float adc2 = pgm_read_word(&temptable_100K[i][0]);
-          float temp1 = pgm_read_word(&temptable_100K[i-1][1]);
-          float temp2 = pgm_read_word(&temptable_100K[i][1]);
-          return temp1 + (temp2 - temp1) * (rawADC - adc1) / (adc2 - adc1);
-        }
-      }
-      return 0.0;
-    }
     uint8_t _pin;
     int _lastRaw = 0;
 };

--- a/src/thermistor.cpp
+++ b/src/thermistor.cpp
@@ -1,0 +1,24 @@
+#include "thermistor.h"
+
+const short temptable_100K[][2] PROGMEM = {
+  {    1, 864 }, {   21, 300 }, {   25, 290 }, {   29, 280 },
+  {   33, 270 }, {   39, 260 }, {   46, 250 }, {   54, 240 },
+  {   64, 230 }, {   75, 220 }, {   90, 210 }, {  107, 200 },
+  {  128, 190 }, {  154, 180 }, {  184, 170 }, {  221, 160 },
+  {  265, 150 }, {  316, 140 }, {  375, 130 }, {  441, 120 },
+  {  513, 110 }, {  588, 100 }, {  734,  80 }, {  856,  60 },
+  {  938,  40 }, {  986,  20 }, { 1008,   0 }, { 1018, -20 }
+};
+
+float computeTemp(int rawADC) {
+  for (uint8_t i = 1; i < sizeof(temptable_100K)/sizeof(*temptable_100K); i++) {
+    if (pgm_read_word(&temptable_100K[i][0]) > rawADC) {
+      float adc1 = pgm_read_word(&temptable_100K[i-1][0]);
+      float adc2 = pgm_read_word(&temptable_100K[i][0]);
+      float temp1 = pgm_read_word(&temptable_100K[i-1][1]);
+      float temp2 = pgm_read_word(&temptable_100K[i][1]);
+      return temp1 + (temp2 - temp1) * (rawADC - adc1) / (adc2 - adc1);
+    }
+  }
+  return 0.0;
+}

--- a/test/thermistor_compute_temp_test.cpp
+++ b/test/thermistor_compute_temp_test.cpp
@@ -1,0 +1,23 @@
+#include <unity.h>
+#include "thermistor.h"
+
+void test_exact_table_value() {
+    TEST_ASSERT_FLOAT_WITHIN(0.01, 110.0f, computeTemp(513));
+}
+
+void test_interpolated_value() {
+    float expected = 110.0f + (100.0f - 110.0f) * (550.0f - 513.0f) / (588.0f - 513.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.01, expected, computeTemp(550));
+}
+
+void test_out_of_range() {
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, computeTemp(2000));
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_exact_table_value);
+    RUN_TEST(test_interpolated_value);
+    RUN_TEST(test_out_of_range);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Extract thermistor lookup table and temperature computation to dedicated module
- Add unit tests validating thermistor temperature interpolation and out-of-range handling

## Testing
- `platformio test -e native` *(fails: platformio not installed)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66e1628c832a9fc9d79838e7e30f